### PR TITLE
fix(android,ios): remove method channel handler cleanup on dispose

### DIFF
--- a/android/src/main/kotlin/com/filledstacks/plugins/flutter_igolf_viewer/FlutterIgolfViewer.kt
+++ b/android/src/main/kotlin/com/filledstacks/plugins/flutter_igolf_viewer/FlutterIgolfViewer.kt
@@ -141,7 +141,6 @@ internal class FlutterIgolfViewer(
 
     override fun dispose() {
         course3DViewer.viewer.onDestroy()
-        methodChannel.setMethodCallHandler(null)
     }
 
     private fun loadCourseData(

--- a/ios/Classes/FlutterIgolfView.swift
+++ b/ios/Classes/FlutterIgolfView.swift
@@ -681,8 +681,6 @@ class FlutterIgolfView: NSObject, FlutterPlatformView, CourseRenderViewDelegate 
     }
 
     deinit {
-        // print("[IGolfViewer3D-Flutter] Deinit")
-        _methodChannel?.setMethodCallHandler(nil)
         _wrapperView.cleanup()
     }
 }


### PR DESCRIPTION
## Summary
- Remove explicit `setMethodCallHandler(null/nil)` calls on dispose/deinit in both Android and iOS
- The handler is automatically cleared when the view instance is deallocated, making the explicit cleanup unnecessary

## Test plan
- [ ] Verify Android viewer opens and closes without crashes
- [ ] Verify iOS viewer opens and closes without crashes
- [ ] Confirm no memory leaks when navigating away from the viewer