### PR TITLE
feat(android): Shot Vision — drawShotVision/clearShotVision tap-to-aim overlay (0.8.8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.8.8
+
+* feat(android): Shot Vision overlay — new `drawShotVision`/`clearShotVision` method-channel handlers draw a 3D rising flight-arc ribbon from the viewer's own golfer position up to a tapped GPS target, plus a ground ring at the target. Arc apex fraction, ribbon width (metres) and colour are passed per call so consumers can tune the look from Dart without a plugin rebuild. Backed by new native `SurfaceViewer.setShotArc`/`clearShotArc` in `iGolfViewerStandard.aar` (release build; source in `viewer_sample_app` — the arc is real 3D geometry in the main render pass, so unlike the custom-overlay dots/lines it is not baked flat into the terrain). Android-only; iOS returns `notImplemented`.
+
 ## 0.8.7
 
 * fix(ios): smooth flyover heading updates by clamping rotation overshoot in the vendored `IGolfViewer3D.xcframework`

--- a/android/src/main/kotlin/com/filledstacks/plugins/flutter_igolf_viewer/FlutterIgolfViewer.kt
+++ b/android/src/main/kotlin/com/filledstacks/plugins/flutter_igolf_viewer/FlutterIgolfViewer.kt
@@ -19,6 +19,7 @@ import com.l1inc.viewer.Course3DViewer
 import com.l1inc.viewer.HoleWithinCourse
 import com.l1inc.viewer.common.Viewer.CurrentHoleChangedListener
 import com.l1inc.viewer.common.Viewer.HoleLoadingStateChangedListener
+import com.l1inc.viewer.drawing.custom.CustomOverlay
 import io.flutter.plugin.common.BinaryMessenger
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
@@ -336,6 +337,8 @@ internal class FlutterIgolfViewer(
                 "setCurrentLocationGPS" -> setCurrentLocationGPS(call, result)
                 "setMeasurementSystem" -> setMeasurementSystem(call, result)
                 "setFreeCamZoom" -> setFreeCamZoom(call, result)
+                "drawShotVision" -> drawShotVision(call, result)
+                "clearShotVision" -> clearShotVision(call, result)
                 else -> result.notImplemented()
             }
         } catch (e: RuntimeException) {
@@ -422,6 +425,72 @@ internal class FlutterIgolfViewer(
             return
         }
         course3DViewer.viewer.setFreeCamZoomScale(freeCamZoomScale(zoom))
+        result.success(null)
+    }
+
+    // --- Shot Vision (tap-to-aim overlay) ---
+    // Stable id so each new tap replaces the previous ring rather than stacking.
+    private val shotVisionDotId = 9002
+
+    /**
+     * Draws the Shot Vision overlay: a 3D rising flight arc from the tapped
+     * point up to the green centre (rendered natively as real geometry, so it
+     * leaves the ground like a shot tracer), plus a ground ring marking the
+     * tapped point. Green coords come from Dart; if absent, only the ring shows.
+     */
+    private fun drawShotVision(call: MethodCall, result: MethodChannel.Result) {
+        val targetLatitude = call.argument<Double>("targetLatitude")
+        val targetLongitude = call.argument<Double>("targetLongitude")
+        if (targetLatitude == null || targetLongitude == null) {
+            result.error("INVALID_ARGS", "Missing target latitude/longitude", null)
+            return
+        }
+
+        val target = Location("").apply {
+            latitude = targetLatitude
+            longitude = targetLongitude
+        }
+
+        val ringBorderColor = Color.argb(255, 7, 197, 255)
+        val ringFillColor = Color.argb(110, 7, 197, 255)
+
+        // Replace any prior shot.
+        course3DViewer.viewer.clearShotArc()
+        course3DViewer.viewer.removeAllDotArrays()
+
+        // 3D rising flight arc from the user's position up to the tapped target.
+        // The arc START is the viewer's own golfer position (native), so only the
+        // tapped point + look knobs (apex/width/colour) come from Dart — the
+        // knobs are tunable via hot reload without rebuilding this AAR.
+        val apexFraction = call.argument<Double>("arcApexFraction") ?: 0.16
+        val lineWidth = (call.argument<Double>("arcLineWidth") ?: 8.0).toFloat()
+        val color = call.argument<Number>("arcColor")?.toInt()
+            ?: Color.argb(255, 7, 197, 255)
+        course3DViewer.viewer.setShotArc(
+            targetLatitude,
+            targetLongitude,
+            apexFraction,
+            lineWidth,
+            color
+        )
+
+        // Ground ring marking the tapped target.
+        course3DViewer.viewer.addDotArray(
+            CustomOverlay.DotArrayBuilder(shotVisionDotId, arrayListOf(target))
+                .borderColor(ringBorderColor)
+                .fillColor(ringFillColor)
+                .borderWidth(0.8f)
+                .dotRadius(3.0f)
+                .build()
+        )
+
+        result.success(null)
+    }
+
+    private fun clearShotVision(call: MethodCall, result: MethodChannel.Result) {
+        course3DViewer.viewer.clearShotArc()
+        course3DViewer.viewer.removeAllSegmentLines()
+        course3DViewer.viewer.removeAllDotArrays()
         result.success(null)
     }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_igolf_viewer
 description: "The igolf plugin for Flutter"
-version: 0.8.7
+version: 0.8.8
 homepage:
 
 environment:


### PR DESCRIPTION
## What

Adds two Android method-channel handlers:

- **`drawShotVision(targetLatitude, targetLongitude, arcApexFraction, arcLineWidth, arcColor)`** — draws a 3D rising flight-arc ribbon from the viewer's own golfer position (resolved natively from `currentLocation`, so Dart never guesses GPS) up to the tapped/computed GPS target, plus a cyan ground ring at the target. Look knobs are per-call → tunable from Dart via hot reload. Each draw replaces the previous shot.
- **`clearShotVision()`** — removes arc + ring.

iOS falls through to `notImplemented` (the app side gates on Android and no-ops elsewhere, leaving existing iOS tap behaviour untouched).

## AAR

`iGolfViewerStandard.aar` updated to a **release** build (`BUILD_TYPE=release`, verified via `javap`) containing `SurfaceViewer.setShotArc/clearShotArc`. Built from committed source: [`ferrarafer/viewer_sample_app#5`](https://github.com/ferrarafer/viewer_sample_app/pull/5), which also syncs the previously-uncommitted sources for the free-cam zoom / rate-cap / tap-to-move features already shipped in this AAR — the binary is now reproducible from source. **Merge that PR first** (or together with this one).

## Version

`0.8.7 → 0.8.8` + CHANGELOG entry.

## Consumer

Pinned Golf `aymen/shot-vision` (app-side toggle + `ViewerService.drawShotVision`); the same channel API is the base for the upcoming shot-recommendation feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)