### PR TITLE
fix(android): release GL surface producer before reconnect across activity pause/resume

### DIFF
--- a/android/src/main/kotlin/com/filledstacks/plugins/flutter_igolf_viewer/FlutterIgolfFactory.kt
+++ b/android/src/main/kotlin/com/filledstacks/plugins/flutter_igolf_viewer/FlutterIgolfFactory.kt
@@ -3,6 +3,7 @@ package com.filledstacks.plugins.flutter_igolf_viewer
 import android.content.Context
 import com.filledstacks.plugins.flutter_igolf_viewer.channels.CourseViewerEventChannel
 import com.filledstacks.plugins.flutter_igolf_viewer.FlutterIgolfViewer
+import com.filledstacks.plugins.flutter_igolf_viewer.lifecycle.ViewerLifecycleRegistry
 import io.flutter.plugin.common.BinaryMessenger
 import io.flutter.plugin.common.EventChannel
 import io.flutter.plugin.common.StandardMessageCodec
@@ -10,14 +11,15 @@ import io.flutter.plugin.platform.PlatformView
 import io.flutter.plugin.platform.PlatformViewFactory
 import io.flutter.plugin.platform.PlatformViewRegistry
 
-class FlutterIgolfViewerFactory(
+internal class FlutterIgolfViewerFactory(
     private val messenger: BinaryMessenger,
-    private val eventChannel: CourseViewerEventChannel
+    private val eventChannel: CourseViewerEventChannel,
+    private val lifecycleRegistry: ViewerLifecycleRegistry
 ) : PlatformViewFactory(StandardMessageCodec.INSTANCE) {
 
     override fun create(context: Context, viewId: Int, args: Any?): PlatformView {
         val params = args as Map<String?, Any?>?
-        return FlutterIgolfViewer(context, messenger, eventChannel, viewId, params)
+        return FlutterIgolfViewer(context, messenger, eventChannel, lifecycleRegistry, viewId, params)
     }
 
 }

--- a/android/src/main/kotlin/com/filledstacks/plugins/flutter_igolf_viewer/FlutterIgolfViewer.kt
+++ b/android/src/main/kotlin/com/filledstacks/plugins/flutter_igolf_viewer/FlutterIgolfViewer.kt
@@ -10,6 +10,8 @@ import android.view.View
 import android.widget.TextView
 import androidx.annotation.VisibleForTesting
 import com.filledstacks.plugins.flutter_igolf_viewer.channels.CourseViewerEventChannel
+import com.filledstacks.plugins.flutter_igolf_viewer.lifecycle.PausableViewer
+import com.filledstacks.plugins.flutter_igolf_viewer.lifecycle.ViewerLifecycleRegistry
 import com.filledstacks.plugins.flutter_igolf_viewer.network.Network
 import com.google.gson.Gson
 import com.l1inc.viewer.Course3DRenderer
@@ -45,9 +47,10 @@ internal class FlutterIgolfViewer(
     context: Context,
     messenger: BinaryMessenger,
     eventChannel: CourseViewerEventChannel,
+    private val lifecycleRegistry: ViewerLifecycleRegistry,
     id: Int,
     creationParams: Map<String?, Any?>?
-) : PlatformView, MethodChannel.MethodCallHandler {
+) : PlatformView, MethodChannel.MethodCallHandler, PausableViewer {
 
     private val course3DViewer: Course3DViewer
 
@@ -76,6 +79,20 @@ internal class FlutterIgolfViewer(
         methodChannel.setMethodCallHandler(this)
 
         course3DViewer = Course3DViewer(context)
+
+        // Keep the EGL context (shaders, programs, textures) alive across an
+        // activity pause. Only the EGL *surface* is released — which is the
+        // part that must disconnect from the Flutter texture's ImageReader —
+        // so resume skips a multi-second course reload and the SDK never
+        // deletes/recreates GL objects against a torn-down context (the
+        // glDeleteShader/glDeleteProgram 0x501 spam seen on pause).
+        course3DViewer.viewer.preserveEGLContextOnPause = true
+
+        // GLSurfaceView contract: the host must forward activity pause/resume
+        // so the GL thread releases its EGL surface (the ImageReader
+        // BufferQueue producer) before the surface is torn down or recreated.
+        // The registry is driven by the plugin's ActivityAware callbacks.
+        lifecycleRegistry.register(this)
 
         course3DViewer.viewer.setOnGPSDistancesUpdatedListener { front, center, back, cursorInsideGreen ->
             eventChannel.sendEvent(mapOf(
@@ -170,8 +187,24 @@ internal class FlutterIgolfViewer(
         return course3DViewer
     }
 
+    override fun pauseRendering() {
+        if (isDisposed) return
+        // Blocks until the GL thread has released its EGL surface, which
+        // disconnects the BufferQueue producer from the Flutter texture's
+        // ImageReader. This must complete before the surface is torn down /
+        // recreated, otherwise the resume-time reconnect is rejected with
+        // "connect: already connected" and the queue is left producer-less.
+        course3DViewer.viewer.onPause()
+    }
+
+    override fun resumeRendering() {
+        if (isDisposed) return
+        course3DViewer.viewer.onResume()
+    }
+
     override fun dispose() {
         isDisposed = true
+        lifecycleRegistry.unregister(this)
         mainHandler.removeCallbacksAndMessages(null)
         // Best-effort: if the background viewer.init thread is still inside
         // the SDK call, ask it to bail. The SDK is closed-source and may not
@@ -183,6 +216,10 @@ internal class FlutterIgolfViewer(
         // onDestroy(). Acceptable given the window is narrow and the SDK
         // is opaque.
         initThread?.interrupt()
+        // Park the GL thread and release the EGL surface first, so the
+        // ImageReader producer is disconnected and no onDrawFrame can be
+        // in flight while onDestroy() tears the renderer's GL objects down.
+        course3DViewer.viewer.onPause()
         course3DViewer.viewer.onDestroy()
     }
 

--- a/android/src/main/kotlin/com/filledstacks/plugins/flutter_igolf_viewer/FlutterIgolfViewer.kt
+++ b/android/src/main/kotlin/com/filledstacks/plugins/flutter_igolf_viewer/FlutterIgolfViewer.kt
@@ -88,12 +88,6 @@ internal class FlutterIgolfViewer(
         // glDeleteShader/glDeleteProgram 0x501 spam seen on pause).
         course3DViewer.viewer.preserveEGLContextOnPause = true
 
-        // GLSurfaceView contract: the host must forward activity pause/resume
-        // so the GL thread releases its EGL surface (the ImageReader
-        // BufferQueue producer) before the surface is torn down or recreated.
-        // The registry is driven by the plugin's ActivityAware callbacks.
-        lifecycleRegistry.register(this)
-
         course3DViewer.viewer.setOnGPSDistancesUpdatedListener { front, center, back, cursorInsideGreen ->
             eventChannel.sendEvent(mapOf(
                 "event" to "GPS_DISTANCES_UPDATED",
@@ -181,6 +175,18 @@ internal class FlutterIgolfViewer(
             creationParams.get("isMetricUnits"),
             creationParams.get("freeCamZoom")
         )
+
+        // GLSurfaceView contract: the host must forward activity pause/resume
+        // so the GL thread releases its EGL surface (the ImageReader
+        // BufferQueue producer) before the surface is torn down or recreated.
+        // The registry is driven by the plugin's ActivityAware callbacks.
+        // Registration is last: if any of the construction above throws
+        // (e.g. loadCourseData rejecting creation params), Flutter never gets
+        // a PlatformView to dispose, so an earlier registration could never
+        // be unregistered and the dead viewer would keep receiving lifecycle
+        // callbacks. The constructor runs on the main thread, as do the
+        // activity lifecycle callbacks, so no pause can slip by before this.
+        lifecycleRegistry.register(this)
     }
 
     override fun getView(): View {

--- a/android/src/main/kotlin/com/filledstacks/plugins/flutter_igolf_viewer/FlutterIgolfViewerPlugin.kt
+++ b/android/src/main/kotlin/com/filledstacks/plugins/flutter_igolf_viewer/FlutterIgolfViewerPlugin.kt
@@ -1,21 +1,38 @@
 package com.filledstacks.plugins.flutter_igolf_viewer
 
+import android.app.Activity
+import android.app.Application
+import android.os.Bundle
 import android.util.Log
 import androidx.annotation.NonNull
 import com.filledstacks.plugins.flutter_igolf_viewer.channels.CourseDetailsApiMethodChannel
 import com.filledstacks.plugins.flutter_igolf_viewer.channels.CourseViewerEventChannel
+import com.filledstacks.plugins.flutter_igolf_viewer.lifecycle.ViewerLifecycleRegistry
 import io.flutter.embedding.engine.plugins.FlutterPlugin
+import io.flutter.embedding.engine.plugins.activity.ActivityAware
+import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
 import io.flutter.plugin.common.EventChannel
 
-class FlutterIgolfViewerPlugin: FlutterPlugin {
+class FlutterIgolfViewerPlugin: FlutterPlugin, ActivityAware {
 
   private lateinit var flutterIgolfViewerFactory: FlutterIgolfViewerFactory
   private lateinit var courseDetailsApiMethodChannel: CourseDetailsApiMethodChannel
   private lateinit var courseViewerEventChannel: CourseViewerEventChannel
+
+  // Forwards the host activity's pause/resume to every live viewer so each
+  // GLSurfaceView releases its EGL surface (the Flutter texture ImageReader's
+  // BufferQueue producer) before the surface is torn down or recreated across
+  // a pause/resume. Without this, the resumed renderer's reconnect is
+  // rejected ("connect: already connected") and the queue is left with no
+  // producer — freezing the Flutter raster thread.
+  private val viewerLifecycleRegistry = ViewerLifecycleRegistry()
+
+  private var boundActivity: Activity? = null
+  private var activityLifecycleCallbacks: Application.ActivityLifecycleCallbacks? = null
 
   private var apiKey = ""
   private var secretKey = ""
@@ -31,7 +48,8 @@ class FlutterIgolfViewerPlugin: FlutterPlugin {
     /// Register PlatformView
     flutterIgolfViewerFactory = FlutterIgolfViewerFactory(
       binding.binaryMessenger,
-      courseViewerEventChannel
+      courseViewerEventChannel,
+      viewerLifecycleRegistry
     )
     binding.platformViewRegistry.registerViewFactory(
       "flutter_igolf_viewer",
@@ -46,5 +64,50 @@ class FlutterIgolfViewerPlugin: FlutterPlugin {
     // Cleanup resources when the plugin is detached from the engine
     courseDetailsApiMethodChannel.cleanup()
     courseViewerEventChannel.cleanup()
+  }
+
+  override fun onAttachedToActivity(binding: ActivityPluginBinding) {
+    observeActivityLifecycle(binding.activity)
+  }
+
+  override fun onDetachedFromActivityForConfigChanges() {
+    stopObservingActivityLifecycle()
+  }
+
+  override fun onReattachedToActivityForConfigChanges(binding: ActivityPluginBinding) {
+    observeActivityLifecycle(binding.activity)
+  }
+
+  override fun onDetachedFromActivity() {
+    stopObservingActivityLifecycle()
+  }
+
+  private fun observeActivityLifecycle(activity: Activity) {
+    stopObservingActivityLifecycle()
+    boundActivity = activity
+    val callbacks = object : Application.ActivityLifecycleCallbacks {
+      override fun onActivityPaused(activity: Activity) {
+        if (activity === boundActivity) viewerLifecycleRegistry.onActivityPaused()
+      }
+
+      override fun onActivityResumed(activity: Activity) {
+        if (activity === boundActivity) viewerLifecycleRegistry.onActivityResumed()
+      }
+
+      override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {}
+      override fun onActivityStarted(activity: Activity) {}
+      override fun onActivityStopped(activity: Activity) {}
+      override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) {}
+      override fun onActivityDestroyed(activity: Activity) {}
+    }
+    activity.application.registerActivityLifecycleCallbacks(callbacks)
+    activityLifecycleCallbacks = callbacks
+  }
+
+  private fun stopObservingActivityLifecycle() {
+    val callbacks = activityLifecycleCallbacks ?: return
+    boundActivity?.application?.unregisterActivityLifecycleCallbacks(callbacks)
+    activityLifecycleCallbacks = null
+    boundActivity = null
   }
 }

--- a/android/src/main/kotlin/com/filledstacks/plugins/flutter_igolf_viewer/lifecycle/PausableViewer.kt
+++ b/android/src/main/kotlin/com/filledstacks/plugins/flutter_igolf_viewer/lifecycle/PausableViewer.kt
@@ -1,0 +1,16 @@
+package com.filledstacks.plugins.flutter_igolf_viewer.lifecycle
+
+/**
+ * Rendering-lifecycle seam between the host activity and a live course viewer.
+ *
+ * The iGolf SDK renders through a [android.opengl.GLSurfaceView], whose
+ * contract requires the host to forward the activity's pause/resume so the GL
+ * thread releases its EGL surface (disconnecting the BufferQueue producer)
+ * before the surface is torn down or recreated. Implemented by
+ * [com.filledstacks.plugins.flutter_igolf_viewer.FlutterIgolfViewer]; kept as
+ * an interface so [ViewerLifecycleRegistry] stays JVM-unit-testable.
+ */
+internal interface PausableViewer {
+    fun pauseRendering()
+    fun resumeRendering()
+}

--- a/android/src/main/kotlin/com/filledstacks/plugins/flutter_igolf_viewer/lifecycle/ViewerLifecycleRegistry.kt
+++ b/android/src/main/kotlin/com/filledstacks/plugins/flutter_igolf_viewer/lifecycle/ViewerLifecycleRegistry.kt
@@ -1,0 +1,57 @@
+package com.filledstacks.plugins.flutter_igolf_viewer.lifecycle
+
+import java.util.concurrent.CopyOnWriteArrayList
+
+/**
+ * Tracks live viewer instances and forwards the host activity's pause/resume
+ * to each of them, exactly once per transition.
+ *
+ * Why this exists: the plugin's platform view wraps a GLSurfaceView that
+ * renders into the Flutter texture's ImageReader (virtual-display platform
+ * view). Without pause forwarding, the GL thread keeps its EGL surface —
+ * the ImageReader BufferQueue's producer — attached across an activity
+ * pause/resume. When the surface is then torn down and recreated, the new
+ * EGL surface's connect is rejected ("connect: already connected"), the old
+ * producer detaches afterwards, and the queue is left with no producer while
+ * the render loop keeps dequeuing — freezing the Flutter raster thread
+ * (5–28 s frame times, app unresponsive). Forwarding pause makes the GL
+ * thread release the EGL surface *before* any teardown, so the resume-time
+ * reconnect always finds a disconnected queue.
+ *
+ * State rules:
+ * - Pause/resume are forwarded only on real transitions (duplicate pause or a
+ *   resume without a prior pause are no-ops — a fresh GLSurfaceView already
+ *   starts resumed).
+ * - A viewer registered while the activity is paused (e.g. created under a
+ *   runtime-permission dialog) is paused immediately so it can't race the
+ *   resume-time reconnect.
+ */
+internal class ViewerLifecycleRegistry {
+    private val viewers = CopyOnWriteArrayList<PausableViewer>()
+
+    @Volatile
+    private var isActivityPaused = false
+
+    fun register(viewer: PausableViewer) {
+        viewers.add(viewer)
+        if (isActivityPaused) {
+            viewer.pauseRendering()
+        }
+    }
+
+    fun unregister(viewer: PausableViewer) {
+        viewers.remove(viewer)
+    }
+
+    fun onActivityPaused() {
+        if (isActivityPaused) return
+        isActivityPaused = true
+        viewers.forEach { it.pauseRendering() }
+    }
+
+    fun onActivityResumed() {
+        if (!isActivityPaused) return
+        isActivityPaused = false
+        viewers.forEach { it.resumeRendering() }
+    }
+}

--- a/android/src/main/kotlin/com/filledstacks/plugins/flutter_igolf_viewer/lifecycle/ViewerLifecycleRegistry.kt
+++ b/android/src/main/kotlin/com/filledstacks/plugins/flutter_igolf_viewer/lifecycle/ViewerLifecycleRegistry.kt
@@ -33,10 +33,13 @@ internal class ViewerLifecycleRegistry {
     private var isActivityPaused = false
 
     fun register(viewer: PausableViewer) {
-        viewers.add(viewer)
+        // Catch-up pause happens BEFORE the viewer is retained: if it throws,
+        // the registry must not keep (and later resume) a viewer whose
+        // construction is about to be aborted by the propagating exception.
         if (isActivityPaused) {
             viewer.pauseRendering()
         }
+        viewers.add(viewer)
     }
 
     fun unregister(viewer: PausableViewer) {

--- a/android/src/test/kotlin/com/filledstacks/plugins/flutter_igolf_viewer/lifecycle/ViewerLifecycleRegistryTest.kt
+++ b/android/src/test/kotlin/com/filledstacks/plugins/flutter_igolf_viewer/lifecycle/ViewerLifecycleRegistryTest.kt
@@ -1,0 +1,121 @@
+package com.filledstacks.plugins.flutter_igolf_viewer.lifecycle
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Unit tests for the activity pause/resume forwarding state machine that keeps
+ * the iGolf GLSurfaceView's EGL surface lifecycle in sync with the host
+ * activity. Regression coverage for the Android freeze where the renderer
+ * reconnected to the Flutter texture's ImageReader while the old producer was
+ * still attached ("connect: already connected" → "no connected producer").
+ */
+internal class ViewerLifecycleRegistryTest {
+
+    private class FakeViewer : PausableViewer {
+        val events = mutableListOf<String>()
+
+        override fun pauseRendering() {
+            events.add("pause")
+        }
+
+        override fun resumeRendering() {
+            events.add("resume")
+        }
+    }
+
+    @Test
+    fun activityPause_forwardsPauseToEveryRegisteredViewer() {
+        val registry = ViewerLifecycleRegistry()
+        val first = FakeViewer()
+        val second = FakeViewer()
+        registry.register(first)
+        registry.register(second)
+
+        registry.onActivityPaused()
+
+        assertEquals(listOf("pause"), first.events)
+        assertEquals(listOf("pause"), second.events)
+    }
+
+    @Test
+    fun activityResume_afterPause_forwardsResume() {
+        val registry = ViewerLifecycleRegistry()
+        val viewer = FakeViewer()
+        registry.register(viewer)
+
+        registry.onActivityPaused()
+        registry.onActivityResumed()
+
+        assertEquals(listOf("pause", "resume"), viewer.events)
+    }
+
+    @Test
+    fun activityResume_withoutPriorPause_isNoOp() {
+        // The first onActivityResumed after startup must not touch the viewer:
+        // a fresh GLSurfaceView is already in the resumed state.
+        val registry = ViewerLifecycleRegistry()
+        val viewer = FakeViewer()
+        registry.register(viewer)
+
+        registry.onActivityResumed()
+
+        assertEquals(emptyList(), viewer.events)
+    }
+
+    @Test
+    fun duplicatePause_forwardsOnlyOnce() {
+        val registry = ViewerLifecycleRegistry()
+        val viewer = FakeViewer()
+        registry.register(viewer)
+
+        registry.onActivityPaused()
+        registry.onActivityPaused()
+
+        assertEquals(listOf("pause"), viewer.events)
+    }
+
+    @Test
+    fun registerWhilePaused_pausesTheNewViewerImmediately() {
+        // A platform view can be created while the activity is paused (e.g. a
+        // runtime permission dialog is up). It must join in the paused state so
+        // its GL thread doesn't race the resumed reconnect.
+        val registry = ViewerLifecycleRegistry()
+        registry.onActivityPaused()
+
+        val viewer = FakeViewer()
+        registry.register(viewer)
+
+        assertEquals(listOf("pause"), viewer.events)
+
+        registry.onActivityResumed()
+        assertEquals(listOf("pause", "resume"), viewer.events)
+    }
+
+    @Test
+    fun unregisteredViewer_receivesNoFurtherEvents() {
+        val registry = ViewerLifecycleRegistry()
+        val viewer = FakeViewer()
+        registry.register(viewer)
+        registry.unregister(viewer)
+
+        registry.onActivityPaused()
+        registry.onActivityResumed()
+
+        assertEquals(emptyList(), viewer.events)
+    }
+
+    @Test
+    fun pauseResumeCycle_repeats() {
+        val registry = ViewerLifecycleRegistry()
+        val viewer = FakeViewer()
+        registry.register(viewer)
+
+        registry.onActivityPaused()
+        registry.onActivityResumed()
+        registry.onActivityPaused()
+        registry.onActivityResumed()
+
+        assertEquals(listOf("pause", "resume", "pause", "resume"), viewer.events)
+    }
+}

--- a/android/src/test/kotlin/com/filledstacks/plugins/flutter_igolf_viewer/lifecycle/ViewerLifecycleRegistryTest.kt
+++ b/android/src/test/kotlin/com/filledstacks/plugins/flutter_igolf_viewer/lifecycle/ViewerLifecycleRegistryTest.kt
@@ -2,6 +2,7 @@ package com.filledstacks.plugins.flutter_igolf_viewer.lifecycle
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 
 /**
  * Unit tests for the activity pause/resume forwarding state machine that keeps
@@ -90,6 +91,30 @@ internal class ViewerLifecycleRegistryTest {
 
         registry.onActivityResumed()
         assertEquals(listOf("pause", "resume"), viewer.events)
+    }
+
+    @Test
+    fun registerWhilePaused_whenInitialPauseFails_doesNotRetainViewer() {
+        val registry = ViewerLifecycleRegistry()
+        registry.onActivityPaused()
+        var resumeCount = 0
+        val viewer = object : PausableViewer {
+            override fun pauseRendering() {
+                throw IllegalStateException("pause failed")
+            }
+
+            override fun resumeRendering() {
+                resumeCount++
+            }
+        }
+
+        assertFailsWith<IllegalStateException> {
+            registry.register(viewer)
+        }
+
+        registry.onActivityResumed()
+
+        assertEquals(0, resumeCount)
     }
 
     @Test

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.9.22'
+    ext.kotlin_version = '2.2.0'
     repositories {
         google()
         mavenCentral()

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -1,4 +1,3 @@
 org.gradle.jvmargs=-Xmx4G
 android.useAndroidX=true
 android.enableJetifier=true
-android.useDeprecatedNdk = true

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip

--- a/example/android/settings.gradle
+++ b/example/android/settings.gradle
@@ -23,7 +23,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.1.0" apply false
+    id "com.android.application" version "8.12.2" apply false
 }
 
 include ":app"

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -81,7 +81,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.8.7"
+    version: "0.8.8"
   flutter_lints:
     dependency: "direct dev"
     description:
@@ -157,10 +157,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   path:
     dependency: transitive
     description:
@@ -250,10 +250,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.11"
   vector_math:
     dependency: transitive
     description:
@@ -279,5 +279,5 @@ packages:
     source: hosted
     version: "3.0.4"
 sdks:
-  dart: ">=3.9.0-0 <4.0.0"
+  dart: ">=3.10.0-0 <4.0.0"
   flutter: ">=3.18.0-18.0.pre.54"


### PR DESCRIPTION
## Bug

While the 3D course viewer is on screen, any activity pause/resume (a runtime location-permission dialog, backgrounding the app) freezes the whole Flutter app on Android. From adb logcat on the Caddie tablet emulator:

1. Activity backgrounds → the viewer's GL context is torn down; two short-lived GL threads spam `glDeleteShader`/`glDeleteProgram` GL error 0x501 (deletes against a wrong/dead context).
2. `BufferQueueProducer [ImageReader-800x1244] connect: already connected (cur=1 req=1)` — the recreated renderer tried to connect its EGL surface to the Flutter texture's ImageReader while the old renderer's producer was still attached; the connect was rejected.
3. The old producer then disconnected, leaving the BufferQueue with **no producer at all** → endless `dequeueBuffer: BufferQueue has no connected producer` (185 hits), Flutter raster thread stalling at 5,000–28,000 ms per frame. No crash, no ANR — the app just hangs.

## Root cause

`SurfaceViewer` (iGolf SDK) extends `GLSurfaceView`, whose contract requires the host to forward the activity's `onPause()`/`onResume()`. The plugin never did — it wasn't even `ActivityAware` — so the GL thread never released its EGL surface (the ImageReader BufferQueue's producer) before the surface was torn down and recreated, and the resume-time reconnect raced the still-attached old producer.

## Fix

- `FlutterIgolfViewerPlugin` is now `ActivityAware` and observes the bound activity's pause/resume via `Application.ActivityLifecycleCallbacks`.
- New `ViewerLifecycleRegistry` (pure Kotlin) forwards each transition exactly once to every live viewer; a viewer created while the activity is already paused (the permission-dialog case) is paused immediately so it can't race the resume reconnect.
- `FlutterIgolfViewer` implements the new `PausableViewer` seam: pause calls `GLSurfaceView.onPause()`, which blocks until the GL thread has released the EGL surface — i.e. the producer is disconnected **before** any teardown/recreate. Resume reconnects against a clean queue, so the "already connected" rejection (and the producer-less end state it caused) can no longer occur.
- `preserveEGLContextOnPause = true`: only the EGL surface is released on pause; the context (shaders/programs/textures) survives — eliminating the 0x501 delete spam and skipping a full course reload on resume.
- `dispose()` parks the GL thread (`onPause()`) before `onDestroy()` so SDK teardown never runs with a frame in flight.

## Tests

The forwarding state machine is extracted as pure Kotlin and unit-tested (`ViewerLifecycleRegistryTest`, 7 cases: fan-out, transition dedup, register-while-paused, unregister, repeated cycles). The `GLSurfaceView.onPause()`/`onResume()` calls themselves are Android-framework behavior and are covered by manual verification on the consuming app (pinned_golf): open 3D viewer → background/foreground + permission dialog → no `connect: already connected`, no `no connected producer`, no 0x501 spam; viewer keeps rendering and responding.

The second commit modernizes the example's Android toolchain (AGP 8.12.2 / Kotlin 2.2.0 / Gradle 8.14.3) — required to run the plugin unit tests with current Flutter; same versions the consuming pinned_golf app already builds with.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EomoqrSYJHpmggbBMWoKZq