### PR TITLE
fix(android): scope Shot Vision clearing to its own overlay

### DIFF
--- a/android/src/main/kotlin/com/filledstacks/plugins/flutter_igolf_viewer/FlutterIgolfViewer.kt
+++ b/android/src/main/kotlin/com/filledstacks/plugins/flutter_igolf_viewer/FlutterIgolfViewer.kt
@@ -497,9 +497,11 @@ internal class FlutterIgolfViewer(
         val ringBorderColor = Color.argb(255, 7, 197, 255)
         val ringFillColor = Color.argb(110, 7, 197, 255)
 
-        // Replace any prior shot.
+        // Replace any prior shot. Shot Vision owns only the arc and its own
+        // ring (shotVisionDotId) — removing by id keeps dot arrays drawn by
+        // other features intact. removeDotArray on an absent id is a no-op.
         course3DViewer.viewer.clearShotArc()
-        course3DViewer.viewer.removeAllDotArrays()
+        course3DViewer.viewer.removeDotArray(shotVisionDotId)
 
         // 3D rising flight arc from the user's position up to the tapped target.
         // The arc START is the viewer's own golfer position (native), so only the
@@ -531,9 +533,11 @@ internal class FlutterIgolfViewer(
     }
 
     private fun clearShotVision(call: MethodCall, result: MethodChannel.Result) {
+        // Clear only what Shot Vision created: the arc and its ground ring.
+        // It never draws segment lines, and blanket removeAll* calls would
+        // wipe custom overlays owned by other features.
         course3DViewer.viewer.clearShotArc()
-        course3DViewer.viewer.removeAllSegmentLines()
-        course3DViewer.viewer.removeAllDotArrays()
+        course3DViewer.viewer.removeDotArray(shotVisionDotId)
         result.success(null)
     }
 


### PR DESCRIPTION
## Bug

`drawShotVision` and `clearShotVision` (introduced in PR #24) clear with blanket SDK calls:

- `drawShotVision` → `removeAllDotArrays()`
- `clearShotVision` → `removeAllSegmentLines()` + `removeAllDotArrays()`

Shot Vision only ever creates the native shot arc and **one** ground-ring dot array (stable id `9002`, `shotVisionDotId`), and creates no segment lines. The blanket calls wipe any custom overlays other features draw through the same `SurfaceViewer` — flagged in PR #25 review as a pre-existing, non-blocking follow-up.

## Fix

Both paths now clear exactly what Shot Vision owns:

- `clearShotArc()` (the arc is Shot Vision's own)
- `removeDotArray(shotVisionDotId)` instead of `removeAllDotArrays()`
- the `removeAllSegmentLines()` call is dropped entirely

`SurfaceViewer.removeDotArray(int)` delegates to `LayerDotArray.removeDotArray`, which null-checks the id lookup — removing an absent id is a safe no-op (verified against the AAR bytecode), so first-tap and double-clear behave as before.

## Tests

Behavior lives entirely in calls into the opaque closed-source iGolf SDK (`Course3DViewer` is constructed directly, no seam), so there is no pure logic to unit test; the full plugin unit suite (14 tests) passes and the plugin compiles against the AAR's `removeDotArray(int)`. Manual verification path: tap to draw Shot Vision with another custom overlay on screen → clear Shot Vision → the other overlay must survive.

## Stacking

Based on `fix/android-gl-surface-lifecycle` (PR #25) because the example-app Android toolchain modernization needed to run plugin unit tests lives there — `main`'s example is still on AGP 8.1.0, which current Flutter refuses to build. Merge after #25; GitHub will retarget this PR to `main` automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RuB6d3s1LQMWNTBXVar9DK