### PR TITLE
fix(android): scope Shot Vision clearing to its own overlay

### DIFF
--- a/android/src/main/kotlin/com/filledstacks/plugins/flutter_igolf_viewer/FlutterIgolfViewer.kt
+++ b/android/src/main/kotlin/com/filledstacks/plugins/flutter_igolf_viewer/FlutterIgolfViewer.kt
@@ -497,9 +497,11 @@ internal class FlutterIgolfViewer(
         val ringBorderColor = Color.argb(255, 7, 197, 255)
         val ringFillColor = Color.argb(110, 7, 197, 255)
 
-        // Replace any prior shot.
+        // Replace any prior shot. Shot Vision owns only the arc and its own
+        // ring (shotVisionDotId) — removing by id keeps dot arrays drawn by
+        // other features intact. removeDotArray on an absent id is a no-op.
         course3DViewer.viewer.clearShotArc()
-        course3DViewer.viewer.removeAllDotArrays()
+        course3DViewer.viewer.removeDotArray(shotVisionDotId)
 
         // 3D rising flight arc from the user's position up to the tapped target.
         // The arc START is the viewer's own golfer position (native), so only the
@@ -531,9 +533,11 @@ internal class FlutterIgolfViewer(
     }
 
     private fun clearShotVision(call: MethodCall, result: MethodChannel.Result) {
+        // Clear only what Shot Vision created: the arc and its ground ring.
+        // It never draws segment lines, and blanket removeAll* calls would
+        // wipe custom overlays owned by other features.
         course3DViewer.viewer.clearShotArc()
-        course3DViewer.viewer.removeAllSegmentLines()
-        course3DViewer.viewer.removeAllDotArrays()
+        course3DViewer.viewer.removeDotArray(shotVisionDotId)
         result.success(null)
     }
 


### PR DESCRIPTION
Re-lands #26 against `main`.

#26 was merged into its stacked base `fix/android-gl-surface-lifecycle` instead of `main` — the base branch's own PR (#25) had already been rebase-merged, so GitHub never retargeted the stack and the fix never reached `main`. This PR cherry-picks that commit (`d0f4ab6`) onto `main`; it applied cleanly since main's content matches the branch.

See #26 for the full context, review discussion, and test notes. Summary: `drawShotVision`/`clearShotVision` cleared with blanket `removeAllDotArrays()`/`removeAllSegmentLines()` calls, wiping any custom overlays other features draw through the same `SurfaceViewer`. Both paths now clear exactly what Shot Vision owns: `clearShotArc()` + `removeDotArray(shotVisionDotId)`.

After this merges, `fix/android-gl-surface-lifecycle` and `fix/shot-vision-scoped-clear` can both be deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qf1rVe79vy6n9oatGeiYbi